### PR TITLE
Fix app icon corner radius at different sizes

### DIFF
--- a/main/src/assets/scss/common/_icon.scss
+++ b/main/src/assets/scss/common/_icon.scss
@@ -92,8 +92,8 @@
 
 .icon-shadow {
 	background: linear-gradient(180deg, #F7FAFC 0%, #F0F2F5 100%);
-	box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
-	border-radius: 12px;
+	box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.2);
+	border-radius: 18.75%;
 	box-sizing: border-box;
 	overflow: hidden;
 }


### PR DESCRIPTION
The 12px corner radius for the icons was only correct for 64px wide icons. In some views they are displayed as 128px though, where 24px would be appropriate. I changed it to a percentual value now.

(And slightly changed the box-shadow to make it look better...)